### PR TITLE
Add xRegistry links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # JsonDiff
+[![Registry](https://img.shields.io/badge/Registry-SpecWorks-blue)](https://spec-works.github.io/registry/parts/jsondiff/)
+
 
 Software component for generating JSON Patch (RFC 6902) documents by comparing two JSON objects.
 

--- a/specs.json
+++ b/specs.json
@@ -23,6 +23,11 @@
       "type": "text/html",
       "rel": "related",
       "title": "RFC 6901 - JSON Pointer (used by JSON Patch for path notation)"
+    },
+    {
+      "rel": "registry",
+      "title": "Part registry entry",
+      "href": "https://spec-works.github.io/registry/parts/jsondiff/"
     }
   ]
 }


### PR DESCRIPTION
Adds xRegistry links for specification-centric component discovery.

## Changes

- **specs.json**: Added registry link (rel: registry)
- **README.md**: Added registry badge

## Registry Entry

This part is now discoverable in the SpecWorks registry.

## Related

- spec-works/specification#6 (Deploy xRegistry using GitHub Pages)
- Phase 5: Integration with parts