### PR TITLE
Standardize documentation theme

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -3,7 +3,9 @@
     {
       "src": [
         {
-          "files": ["SpecWorks.JsonDiff/SpecWorks.JsonDiff.csproj"],
+          "files": [
+            "SpecWorks.JsonDiff/SpecWorks.JsonDiff.csproj"
+          ],
           "src": "../dotnet/src"
         }
       ],
@@ -17,20 +19,41 @@
   "build": {
     "content": [
       {
-        "files": ["api/**.yml", "api/index.md"]
+        "files": [
+          "api/**.yml",
+          "api/index.md"
+        ]
       },
       {
-        "files": ["**.md", "**.yml"],
-        "exclude": ["obj/**", "_site/**", "**/bin/**", "**/obj/**"]
+        "files": [
+          "**.md",
+          "**.yml"
+        ],
+        "exclude": [
+          "obj/**",
+          "_site/**",
+          "**/bin/**",
+          "**/obj/**"
+        ]
       }
     ],
     "resource": [
       {
-        "files": ["images/**"]
+        "files": [
+          "images/**"
+        ]
+      },
+      {
+        "files": [
+          "styles/**"
+        ]
       }
     ],
     "output": "_site",
-    "template": ["default", "modern"],
+    "template": [
+      "default",
+      "modern"
+    ],
     "globalMetadata": {
       "_appTitle": "JsonDiff Documentation",
       "_appName": "JsonDiff",
@@ -40,7 +63,12 @@
       "_gitContribute": {
         "repo": "https://github.com/spec-works/JsonDiff",
         "branch": "main"
-      }
+      },
+      "_appLogoPath": "images/logo.svg",
+      "_appFaviconPath": "images/logo.svg",
+      "_extraCss": [
+        "styles/main.css"
+      ]
     }
   }
 }

--- a/docs/images/logo.svg
+++ b/docs/images/logo.svg
@@ -1,0 +1,15 @@
+<svg width="40" height="40" xmlns="http://www.w3.org/2000/svg">
+  <!-- Factory gear icon -->
+  <g transform="translate(0, 0)">
+    <!-- Outer gear -->
+    <circle cx="20" cy="20" r="18" fill="none" stroke="#0066cc" stroke-width="3"/>
+    <!-- Inner circle -->
+    <circle cx="20" cy="20" r="10" fill="#0066cc"/>
+    <!-- Gear teeth -->
+    <path d="M 20 2 L 22 8 L 18 8 Z M 38 20 L 32 22 L 32 18 Z M 20 38 L 18 32 L 22 32 Z M 2 20 L 8 18 L 8 22 Z" fill="#0066cc"/>
+    <!-- Spec symbol (document) -->
+    <rect x="12" y="15" width="16" height="10" fill="white" opacity="0.9" rx="1"/>
+    <line x1="14" y1="18" x2="26" y2="18" stroke="#0066cc" stroke-width="1"/>
+    <line x1="14" y1="21" x2="26" y2="21" stroke="#0066cc" stroke-width="1"/>
+  </g>
+</svg>

--- a/docs/styles/main.css
+++ b/docs/styles/main.css
@@ -1,0 +1,34 @@
+/* SpecWorks minimal theme - respects light/dark mode */
+
+/* Logo and branding alignment */
+.navbar-brand {
+  display: flex;
+  align-items: center;
+  gap: 20px; /* Increased spacing between logo and text */
+}
+
+.navbar-brand img {
+  margin-right: 0;
+}
+
+/* Ensure navigation items are vertically aligned */
+.navbar-nav {
+  align-items: center;
+}
+
+/* Minimal enhancements that work with both themes */
+.navbar {
+  border-bottom: 1px solid var(--bs-border-color);
+}
+
+/* Improve code readability */
+pre code {
+  line-height: 1.5;
+}
+
+/* Card hover effect */
+.card:hover {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  transform: translateY(-2px);
+  transition: all 0.2s ease;
+}

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -1,3 +1,5 @@
+- name: ← SpecWorks Factory
+  href: https://spec-works.github.io/
 - name: Home
   href: index.md
 - name: API Reference


### PR DESCRIPTION
Added:
- SpecWorks logo (docs/images/logo.svg)
- Shared theme CSS (docs/styles/main.css)
- Logo configuration in docfx.json
- Link to SpecWorks Factory in navigation

Documentation now matches the main landing page theme and
provides navigation back to https://spec-works.github.io/
