### PR TITLE
chore: update target frameworks to net10.0;net8.0 per org conventions

### DIFF
--- a/dotnet/src/SpecWorks.JsonDiff.Cli/SpecWorks.JsonDiff.Cli.csproj
+++ b/dotnet/src/SpecWorks.JsonDiff.Cli/SpecWorks.JsonDiff.Cli.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/dotnet/src/SpecWorks.JsonDiff/SpecWorks.JsonDiff.csproj
+++ b/dotnet/src/SpecWorks.JsonDiff/SpecWorks.JsonDiff.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -39,9 +39,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="9.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="10.0.7" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="System.Text.Json" Version="9.0.0" />
+    <PackageReference Include="System.Text.Json" Version="10.0.7" />
     <PackageReference Include="SystemTextJson.JsonDiffPatch" Version="2.0.0" />
   </ItemGroup>
 

--- a/dotnet/tests/SpecWorks.JsonDiff.Tests/SpecWorks.JsonDiff.Tests.csproj
+++ b/dotnet/tests/SpecWorks.JsonDiff.Tests/SpecWorks.JsonDiff.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
## Summary
Aligns JsonDiff with the org-wide convention defined in `specification/CONVENTIONS.md` (lines 107-112):

> All .NET projects must multi-target: `net10.0;net8.0`
> **Rationale:** Support both latest .NET (10.0) and current LTS version (8.0).

## Changes
| Project | Before | After |
|---|---|---|
| Library (`SpecWorks.JsonDiff`) | `net9.0;net8.0` | `net10.0;net8.0` |
| CLI (`SpecWorks.JsonDiff.Cli`) | `net9.0` | `net10.0` |
| Tests (`SpecWorks.JsonDiff.Tests`) | `net9.0` | `net10.0` |

### NuGet Package Updates
- `Microsoft.AspNetCore.JsonPatch`: 9.0.0 → 10.0.7
- `System.Text.Json`: 9.0.0 → 10.0.7

## Verification
- ✅ `dotnet build` — 0 warnings, 0 errors
- ✅ `dotnet test` — 111/111 tests passed on net10.0